### PR TITLE
Set process_limits before limits

### DIFF
--- a/lib/sidekiq/limit_fetch/queues.rb
+++ b/lib/sidekiq/limit_fetch/queues.rb
@@ -9,8 +9,8 @@ class Sidekiq::LimitFetch
 
       options[:strict] ? strict_order! : weighted_order!
 
-      set :limit, options[:limits]
       set :process_limit, options[:process_limits]
+      set :limit, options[:limits]
       set_blocks options[:blocking]
     end
 

--- a/spec/sidekiq/limit_fetch/queues_spec.rb
+++ b/spec/sidekiq/limit_fetch/queues_spec.rb
@@ -3,16 +3,18 @@ require 'spec_helper'
 RSpec.describe Sidekiq::LimitFetch::Queues do
   subject { described_class.new options }
 
-  let(:queues)   { %w[queue1 queue2] }
-  let(:limits)   {{ 'queue1' => 3 }}
-  let(:strict)   { true }
-  let(:blocking) {}
+  let(:queues)         { %w[queue1 queue2] }
+  let(:limits)         {{ 'queue1' => 3 }}
+  let(:strict)         { true }
+  let(:blocking)       {}
+  let(:process_limits) {{ 'queue2' => 3 }}
 
   let(:options) do
     { queues:   queues,
       limits:   limits,
       strict:   strict,
       blocking: blocking,
+      process_limits: process_limits,
       namespace: Sidekiq::LimitFetch::Redis.determine_namespace }
   end
 
@@ -80,6 +82,11 @@ RSpec.describe Sidekiq::LimitFetch::Queues do
     subject
     expect(Sidekiq::Queue['queue1'].limit).to eq 3
     expect(Sidekiq::Queue['queue2'].limit).not_to be
+  end
+
+  it 'should set process_limits' do
+    subject
+    expect(Sidekiq::Queue['queue2'].process_limit).to eq 3
   end
 
   context 'without strict flag' do


### PR DESCRIPTION
I noticed today that my process_limits settings in sidekiq.yml weren't being respected. This PR should fix the problem.

I swap the order because setting limits before process_limits makes
the queue.limit_changed? conditional in #set return true and so
process_limits don't get set.

It looks like this bug was introduced with this commit: https://github.com/brainopia/sidekiq-limit_fetch/commit/84ef650ea9bc5d7ec4bb288a594ae8b9bbeff34e