### PR TITLE
Fix constant error

### DIFF
--- a/lib/sidekiq/extensions/manager.rb
+++ b/lib/sidekiq/extensions/manager.rb
@@ -7,7 +7,7 @@ class Sidekiq::Manager
 
     def start
       Sidekiq::LimitFetch::Queues.start options
-      Global::Monitor.start!
+      Sidekiq::LimitFetch::Global::Monitor.start!
       super
     end
   end


### PR DESCRIPTION
```
2015-10-15_09:10:27.19926 uninitialized constant Sidekiq::Manager::InitLimitFetch::Global
2015-10-15_09:10:27.19928 /home/amplifr/amplifr/shared/bundle/ruby/2.2.0/gems/sidekiq-limit_fetch-3.0.0/lib/sidekiq/extensions/manager.rb:10:in `start'
2015-10-15_09:10:27.19929 /home/amplifr/amplifr/shared/bundle/ruby/2.2.0/bundler/gems/sidekiq-9a88a1f810c8/lib/sidekiq/launcher.rb:26:in `run'
2015-10-15_09:10:27.19929 /home/amplifr/amplifr/shared/bundle/ruby/2.2.0/bundler/gems/sidekiq-9a88a1f810c8/lib/sidekiq/cli.rb:87:in `run'
2015-10-15_09:10:27.19929 /home/amplifr/amplifr/shared/bundle/ruby/2.2.0/bundler/gems/sidekiq-9a88a1f810c8/bin/sidekiq:13:in `<top (required)>'
2015-10-15_09:10:27.19930 /home/amplifr/amplifr/shared/bundle/ruby/2.2.0/bin/sidekiq:23:in `load'```