### PR TITLE
Support Sidekiq edge and ruby2.3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: ruby
 rvm:
+  - 2.3.0
   - 2.2.1
   - jruby-head
   - rbx-2

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 gemspec
 
-gem 'sidekiq', github: 'mperham/sidekiq', branch: 'internal_rewrite'
+gem 'sidekiq'

--- a/lib/sidekiq/limit_fetch.rb
+++ b/lib/sidekiq/limit_fetch.rb
@@ -21,9 +21,9 @@ module Sidekiq::LimitFetch
   end
 
   def retrieve_work
-    queue, message = redis_brpop *Queues.acquire, Sidekiq::BasicFetch::TIMEOUT
-    Queues.release_except queue
-    UnitOfWork.new queue, message if message
+    queue, job = redis_brpop *Queues.acquire, Sidekiq::BasicFetch::TIMEOUT
+    Queues.release_except(queue)
+    UnitOfWork.new(queue, job) if job
   end
 
   def bulk_requeue(*args)

--- a/lib/sidekiq/limit_fetch.rb
+++ b/lib/sidekiq/limit_fetch.rb
@@ -8,6 +8,7 @@ module Sidekiq::LimitFetch
 
   require_relative 'limit_fetch/instances'
   require_relative 'limit_fetch/queues'
+  require_relative 'limit_fetch/version'
   require_relative 'limit_fetch/global/semaphore'
   require_relative 'limit_fetch/global/selector'
   require_relative 'limit_fetch/global/monitor'

--- a/lib/sidekiq/limit_fetch.rb
+++ b/lib/sidekiq/limit_fetch.rb
@@ -8,7 +8,6 @@ module Sidekiq::LimitFetch
 
   require_relative 'limit_fetch/instances'
   require_relative 'limit_fetch/queues'
-  require_relative 'limit_fetch/version'
   require_relative 'limit_fetch/global/semaphore'
   require_relative 'limit_fetch/global/selector'
   require_relative 'limit_fetch/global/monitor'

--- a/lib/sidekiq/limit_fetch/unit_of_work.rb
+++ b/lib/sidekiq/limit_fetch/unit_of_work.rb
@@ -1,6 +1,6 @@
 module Sidekiq
   class LimitFetch::UnitOfWork < BasicFetch::UnitOfWork
-    def initialize(queue, message)
+    def initialize(queue, job)
       super
       Queue[queue_name].increase_busy
     end

--- a/lib/sidekiq/limit_fetch/version.rb
+++ b/lib/sidekiq/limit_fetch/version.rb
@@ -1,5 +1,0 @@
-module Sidekiq
-  module LimitFetch
-    VERSION = '3.0.2'
-  end
-end

--- a/lib/sidekiq/limit_fetch/version.rb
+++ b/lib/sidekiq/limit_fetch/version.rb
@@ -1,0 +1,5 @@
+module Sidekiq
+  module LimitFetch
+    VERSION = '3.0.2'
+  end
+end

--- a/sidekiq-limit_fetch.gemspec
+++ b/sidekiq-limit_fetch.gemspec
@@ -1,6 +1,10 @@
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'sidekiq/limit_fetch/version'
+
 Gem::Specification.new do |gem|
   gem.name          = 'sidekiq-limit_fetch'
-  gem.version       = '3.0.1'
+  gem.version       = Sidekiq::LimitFetch::VERSION
   gem.license       = 'MIT'
   gem.authors       = 'brainopia'
   gem.email         = 'brainopia@evilmartians.com'

--- a/sidekiq-limit_fetch.gemspec
+++ b/sidekiq-limit_fetch.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = 'lib'
 
   gem.add_dependency 'sidekiq', '>= 4'
+  gem.add_development_dependency 'redis-namespace', '~> 1.5', '>= 1.5.2'
   gem.add_development_dependency 'rspec'
   gem.add_development_dependency 'rake'
 end

--- a/sidekiq-limit_fetch.gemspec
+++ b/sidekiq-limit_fetch.gemspec
@@ -1,10 +1,6 @@
-lib = File.expand_path('../lib', __FILE__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'sidekiq/limit_fetch/version'
-
 Gem::Specification.new do |gem|
   gem.name          = 'sidekiq-limit_fetch'
-  gem.version       = Sidekiq::LimitFetch::VERSION
+  gem.version       = '3.0.1'
   gem.license       = 'MIT'
   gem.authors       = 'brainopia'
   gem.email         = 'brainopia@evilmartians.com'

--- a/spec/sidekiq/limit_fetch_spec.rb
+++ b/spec/sidekiq/limit_fetch_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Sidekiq::LimitFetch do
   it 'should acquire lock on queue for execution' do
     work = subject.retrieve_work
     expect(work.queue_name).to eq 'queue1'
-    expect(work.message).to eq 'task1'
+    expect(work.job).to eq 'task1'
 
     expect(Sidekiq::Queue['queue1'].busy).to eq 1
     expect(Sidekiq::Queue['queue2'].busy).to eq 0
@@ -31,7 +31,7 @@ RSpec.describe Sidekiq::LimitFetch do
     expect(Sidekiq::Queue['queue2'].busy).to eq 0
 
     work = subject.retrieve_work
-    expect(work.message).to eq 'task1'
+    expect(work.job).to eq 'task1'
 
     expect(Sidekiq::Queue['queue1'].busy).to eq 1
     expect(Sidekiq::Queue['queue2'].busy).to eq 0
@@ -43,6 +43,6 @@ RSpec.describe Sidekiq::LimitFetch do
     expect(Sidekiq::Queue['queue2'].busy).to eq 0
 
     work = subject.retrieve_work
-    expect(work.message).to eq 'task2'
+    expect(work.job).to eq 'task2'
   end
 end


### PR DESCRIPTION
- Fixed specs. Change `UnitOfWork` attribute name. `message` -> `job`
- Remove deprecated method. `Thread.exclusive` -> `Mutex#synchronize`