### PR TITLE
Make namespace symbol friendly

### DIFF
--- a/lib/sidekiq/limit_fetch/queues.rb
+++ b/lib/sidekiq/limit_fetch/queues.rb
@@ -48,7 +48,7 @@ module Sidekiq::LimitFetch::Queues
   def namespace
     @namespace ||= Sidekiq.redis do |it|
       if it.respond_to?(:namespace) and it.namespace
-        it.namespace + ':'
+        "#{it.namespace}:"
       else
         ''
       end

--- a/sidekiq-limit_fetch.gemspec
+++ b/sidekiq-limit_fetch.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |gem|
 
   gem.files         = `git ls-files`.split($/)
   gem.test_files    = gem.files.grep %r{^spec/}
-  gem.require_paths = 'lib'
+  gem.require_paths = %w(lib)
 
   gem.add_dependency 'sidekiq', '>= 4'
   gem.add_development_dependency 'redis-namespace', '~> 1.5', '>= 1.5.2'


### PR DESCRIPTION
Some projects use redis namespaces defined with symbols rather than strings, and currently limit_fetch fails to work with symbol namespaces with following error:

```
Error fetching job: undefined method `+' for :sidekiq:Symbol
```

Update: this may be related to older ruby version (2.1.x). One more fix in gemspec makes this gem buildable and runable on 2.1.x