### PR TITLE
rescue redis connection errors on job fetch

### DIFF
--- a/lib/sidekiq/limit_fetch.rb
+++ b/lib/sidekiq/limit_fetch.rb
@@ -46,7 +46,7 @@ module Sidekiq::LimitFetch
       sleep TIMEOUT  # there are no queues to handle, so lets sleep
       []             # and return nothing
     else
-      Sidekiq.redis { |it| it.brpop *queues, TIMEOUT }
+      redis_retryable { Sidekiq.redis { |it| it.brpop *queues, TIMEOUT } }
     end
   end
 end


### PR DESCRIPTION
related to https://github.com/brainopia/sidekiq-limit_fetch/issues/75