### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ Add this line to your application's Gemfile:
 
 ## Usage
 
+### Require
+You must `require 'sidekiq-limit_fetch'` if it isn't already. It will not work until then.
+
 ### Limits
 
 Specify limits which you want to place on queues inside sidekiq.yml:


### PR DESCRIPTION
Add instructions for users that need to explicitly require the library.
If you are using this gem in an environment where your gems are not auto-required, you may be stumped for a bit as to why your queues aren't limited. This will help understand that they must require the library before their queue's will be limited.