### PR TITLE
Fix demo app

### DIFF
--- a/demo/Gemfile
+++ b/demo/Gemfile
@@ -1,8 +1,6 @@
 source 'https://rubygems.org'
 
 gem 'rails'
-gem 'sinatra'
-gem 'celluloid'
 gem 'launchy'
 gem 'sidekiq', github: 'mperham/sidekiq'
 gem 'sidekiq-limit_fetch', path: '..'

--- a/demo/Rakefile
+++ b/demo/Rakefile
@@ -78,7 +78,7 @@ namespace :demo do
       Rack::Server.start app: Sidekiq::Web, Port: 3000
     end
     sleep 1
-    Launchy.open 'http://127.0.0.1:3000/workers?poll=true'
+    Launchy.open 'http://127.0.0.1:3000/busy?poll=true'
   end
 
   def run_sidekiq_workers(options)


### PR DESCRIPTION
Fix the following issues:

```
% bundle exec rake demo:limit
rake aborted!
LoadError: cannot load such file -- rack/showexceptions
/Users/dany/.ghq/github.com/brainopia/sidekiq-limit_fetch/demo/config/application.rb:7:in `<top (required)>'
/Users/dany/.ghq/github.com/brainopia/sidekiq-limit_fetch/demo/Rakefile:1:in `require'
/Users/dany/.ghq/github.com/brainopia/sidekiq-limit_fetch/demo/Rakefile:1:in `<top (required)>'
/Users/dany/.rbenv/versions/2.2.5/bin/bundle:23:in `load'
/Users/dany/.rbenv/versions/2.2.5/bin/bundle:23:in `<main>'
(See full trace by running task with --trace)
```

Installed gem versions:

- Rails 5.0.0.1
- Sidekiq 4.2.8

Fixed details

- Remove unnecessary gems
  - Remove sinatra dependency after 4.2.0 [changelog](https://github.com/mperham/sidekiq/blob/master/Changes.md#420)
- Fix Sidekiq Web URL
  - The Worker tab is renamed to Busy after 3.0.0 [changelog](https://github.com/mperham/sidekiq/blob/master/Changes.md#300)