### PR TITLE
Fix breaking change in bulk_requeue

### DIFF
--- a/lib/sidekiq/limit_fetch.rb
+++ b/lib/sidekiq/limit_fetch.rb
@@ -27,7 +27,9 @@ module Sidekiq::LimitFetch
   end
 
   def bulk_requeue(*args)
-    Sidekiq::BasicFetch.new(Sidekiq::options).bulk_requeue(*args)
+    klass = Sidekiq::BasicFetch
+    fetch = klass.respond_to?(:bulk_requeue) ? klass : klass.new(Sidekiq::options)
+    fetch.bulk_requeue(*args)
   end
 
   def redis_retryable

--- a/lib/sidekiq/limit_fetch.rb
+++ b/lib/sidekiq/limit_fetch.rb
@@ -27,7 +27,7 @@ module Sidekiq::LimitFetch
   end
 
   def bulk_requeue(*args)
-    Sidekiq::BasicFetch.bulk_requeue(*args)
+    Sidekiq::BasicFetch.new(Sidekiq::options).bulk_requeue(*args)
   end
 
   def redis_retryable

--- a/spec/sidekiq/limit_fetch_spec.rb
+++ b/spec/sidekiq/limit_fetch_spec.rb
@@ -10,13 +10,16 @@ RSpec.describe Sidekiq::LimitFetch do
 
     Sidekiq.redis do |it|
       it.del 'queue:queue1'
-      it.lpush 'queue:queue1', 'task1'
-      it.lpush 'queue:queue1', 'task2'
+      it.del 'queue:queue2'
       it.expire 'queue:queue1', 30
     end
   end
 
   it 'should acquire lock on queue for execution' do
+    Sidekiq.redis do |it|
+      it.lpush 'queue:queue1', 'task1'
+      it.lpush 'queue:queue1', 'task2'
+    end
     work = subject.retrieve_work
     expect(work.queue_name).to eq 'queue1'
     expect(work.job).to eq 'task1'
@@ -44,5 +47,26 @@ RSpec.describe Sidekiq::LimitFetch do
 
     work = subject.retrieve_work
     expect(work.job).to eq 'task2'
+  end
+
+  it 'bulk requeues' do
+    Sidekiq.redis do |it|
+      it.lpush 'queue:queue1', 'task1'
+      it.lpush 'queue:queue2', 'task2'
+      it.lpush 'queue:queue2', 'task3'
+    end
+    q1 = Sidekiq::Queue['queue1']
+    q2 = Sidekiq::Queue['queue2']
+    expect(q1.size).to eq 1
+    expect(q2.size).to eq 2
+
+    fetch = subject.new(queues: ['queue1', 'queue2'])
+    works = 3.times.map { fetch.retrieve_work }
+    expect(q1.size).to eq 0
+    expect(q2.size).to eq 0
+
+    fetch.bulk_requeue(works, queues: [])
+    expect(q1.size).to eq 1
+    expect(q2.size).to eq 2
   end
 end


### PR DESCRIPTION
In Sidekiq version 6.1.0 the internal method `bulk_requeue` became an instance method instead of a class method, this PR should fix this by creating a `Sidekiq::BasicFetch` instance with `Sidekiq::options`.

See https://github.com/brainopia/sidekiq-limit_fetch/issues/110 and https://github.com/mperham/sidekiq/pull/4602