### PR TITLE
Fix compatibility issue for sidekiq v6.1.0+

### DIFF
--- a/lib/sidekiq/limit_fetch.rb
+++ b/lib/sidekiq/limit_fetch.rb
@@ -26,8 +26,14 @@ module Sidekiq::LimitFetch
     UnitOfWork.new(queue, job) if job
   end
 
+  # Backwards compatibility for sidekiq v6.1.0
+  # @see https://github.com/mperham/sidekiq/pull/4602
   def bulk_requeue(*args)
-    Sidekiq::BasicFetch.bulk_requeue(*args)
+    if Sidekiq::BasicFetch.respond_to?(:bulk_requeue) # < 6.1.0
+      Sidekiq::BasicFetch.bulk_requeue(*args)
+    else # 6.1.0+
+      Sidekiq::BasicFetch.new(Sidekiq.options).bulk_requeue(*args)
+    end
   end
 
   def redis_retryable


### PR DESCRIPTION
Hi @brainopia !

Since v6.1.0 Sidekiq::BasicFetcher doesn't support class-level method `bulk_requeue`.
See https://github.com/mperham/sidekiq/pull/4602 for details.
For backwards compatibility we should support both interfaces depending on class method presence.